### PR TITLE
Pass whether the local device is an atv device to the native layer to…

### DIFF
--- a/jni/com_android_bluetooth_btservice_AdapterService.cpp
+++ b/jni/com_android_bluetooth_btservice_AdapterService.cpp
@@ -737,7 +737,7 @@ static void classInitNative(JNIEnv* env, jclass clazz) {
     }
 }
 
-static bool initNative(JNIEnv* env, jobject obj) {
+static bool initNative(JNIEnv* env, jobject obj, jboolean isAtvDevice) {
     ALOGV("%s:",__FUNCTION__);
 
     android_bluetooth_UidTraffic.clazz = (jclass) env->NewGlobalRef(
@@ -751,7 +751,7 @@ static bool initNative(JNIEnv* env, jobject obj) {
     }
 
     if (sBluetoothInterface) {
-        int ret = sBluetoothInterface->init(&sBluetoothCallbacks);
+        int ret = sBluetoothInterface->init(&sBluetoothCallbacks, isAtvDevice == JNI_TRUE ? 1 : 0);
         if (ret != BT_STATUS_SUCCESS && ret != BT_STATUS_DONE) {
             ALOGE("Error while setting the callbacks: %d\n", ret);
             sBluetoothInterface = NULL;
@@ -1444,7 +1444,7 @@ static void interopDatabaseAddNative(JNIEnv *env, jobject obj, int feature,
 static JNINativeMethod sMethods[] = {
     /* name, signature, funcPtr */
     {"classInitNative", "()V", (void *) classInitNative},
-    {"initNative", "()Z", (void *) initNative},
+    {"initNative", "(Z)Z", (void*)initNative},
     {"cleanupNative", "()V", (void*) cleanupNative},
     {"enableNative", "(Z)Z",  (void*) enableNative},
     {"disableNative", "()Z",  (void*) disableNative},

--- a/src/com/android/bluetooth/btservice/AdapterService.java
+++ b/src/com/android/bluetooth/btservice/AdapterService.java
@@ -37,6 +37,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.os.BatteryStats;
 import android.os.Binder;
 import android.os.Bundle;
@@ -524,7 +525,11 @@ public class AdapterService extends Service {
         mVendor = new Vendor(this);
         mAdapterStateMachine =  AdapterState.make(this, mAdapterProperties, mVendor);
         mJniCallbacks =  new JniCallbacks(mAdapterStateMachine, mAdapterProperties);
-        initNative();
+
+        // Android TV doesn't show consent dialogs for just works and encryption only le pairing
+        boolean isAtvDevice = getApplicationContext().getPackageManager().hasSystemFeature(
+                PackageManager.FEATURE_LEANBACK_ONLY);
+        initNative(isAtvDevice);
         mNativeAvailable=true;
         mCallbacks = new RemoteCallbackList<IBluetoothCallback>();
         //Load the name and address
@@ -2813,7 +2818,7 @@ public class AdapterService extends Service {
     };
 
     private native static void classInitNative();
-    private native boolean initNative();
+    private native boolean initNative(boolean isAtvDevice);
     private native void cleanupNative();
     /*package*/ native boolean enableNative(boolean startRestricted);
     /*package*/ native boolean disableNative();


### PR DESCRIPTION
… determine whether to include pairing dialogs for justworks and encryption only LE pairing

Tag: #feature
Bug: 157038281
Test: Manual
Merged-In: Ib7575ff3d5f7e0c208743eff652440f7947dfed7
Change-Id: Ib7575ff3d5f7e0c208743eff652440f7947dfed7
(cherry picked from commit 0b2002b32a8459297d3bb50fce83dfa17e9ed778)